### PR TITLE
FC-682: allow consumers to read uncommitted messages from kafka brokers

### DIFF
--- a/lib/kafka/protocol/fetch_request.rb
+++ b/lib/kafka/protocol/fetch_request.rb
@@ -50,7 +50,7 @@ module Kafka
         encoder.write_int32(@max_wait_time)
         encoder.write_int32(@min_bytes)
         encoder.write_int32(@max_bytes)
-        encoder.write_int8(ISOLATION_READ_COMMITTED)
+        encoder.write_int8(ISOLATION_READ_UNCOMMITTED)
 
         encoder.write_array(@topics) do |topic, partitions|
           encoder.write_string(topic)

--- a/lib/kafka/protocol/list_offset_request.rb
+++ b/lib/kafka/protocol/list_offset_request.rb
@@ -37,7 +37,7 @@ module Kafka
 
       def encode(encoder)
         encoder.write_int32(@replica_id)
-        encoder.write_int8(ISOLATION_READ_COMMITTED)
+        encoder.write_int8(ISOLATION_READ_UNCOMMITTED)
 
         encoder.write_array(@topics) do |topic, partitions|
           encoder.write_string(topic)

--- a/lib/kafka/version.rb
+++ b/lib/kafka/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kafka
-  VERSION = "1.3.0"
+  VERSION = "1.3.0.everfi.1"
 end

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -4,18 +4,11 @@ require "kafka/datadog"
 require "fake_datadog_agent"
 
 describe Kafka::Datadog do
-  let(:agent) { FakeDatadogAgent.new }
-
-  before do
-    agent.start
-  end
-
-  after do
-    agent.stop
-  end
-
   context "when host and port are specified" do
     it "emits metrics to the Datadog agent" do
+      agent = FakeDatadogAgent.new
+      agent.start
+      Kafka::Datadog.socket_path = nil
       Kafka::Datadog.host = agent.host
       Kafka::Datadog.port = agent.port
 
@@ -30,12 +23,17 @@ describe Kafka::Datadog do
       metric = agent.metrics.first
 
       expect(metric).to eq "ruby_kafka.greetings"
+      agent.stop
     end
   end
 
   context "when socket_path is specified" do
     it "emits metrics to the Datadog agent" do
+      agent = FakeDatadogAgent.new
+      agent.start
       Kafka::Datadog.socket_path = agent.socket_path
+      Kafka::Datadog.host = nil
+      Kafka::Datadog.port = nil
 
       client = Kafka::Datadog.statsd
 
@@ -48,6 +46,7 @@ describe Kafka::Datadog do
       metric = agent.metrics.first
 
       expect(metric).to eq "ruby_kafka.greetings"
+      agent.stop
     end
   end
 end

--- a/spec/socket_with_timeout_spec.rb
+++ b/spec/socket_with_timeout_spec.rb
@@ -12,7 +12,9 @@ describe Kafka::SocketWithTimeout, ".open" do
 
     expect {
       Kafka::SocketWithTimeout.new(host, port, connect_timeout: timeout, timeout: 1)
-    }.to raise_exception(Errno::ETIMEDOUT)
+    }.to raise_exception(SystemCallError) { |exception|
+      expect([Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ENETUNREACH]).to include(exception.class)
+    }
 
     finish = Time.now
 

--- a/spec/ssl_socket_with_timeout_spec.rb
+++ b/spec/ssl_socket_with_timeout_spec.rb
@@ -12,7 +12,9 @@ describe Kafka::SSLSocketWithTimeout, ".open" do
 
     expect {
       Kafka::SSLSocketWithTimeout.new(host, port, connect_timeout: timeout, timeout: 1, ssl_context: OpenSSL::SSL::SSLContext.new)
-    }.to raise_exception(Errno::ETIMEDOUT)
+    }.to raise_exception(SystemCallError) { |exception|
+      expect([Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::ENETUNREACH]).to include(exception.class)
+    }
 
     finish = Time.now
 


### PR DESCRIPTION
FC-682

I really wanted to make this configurable on a consumer by consumer
basis, but there is a great deal of spaghetti code that needs to be
unwound in order to be able to pass the isolation level down into each
consumer. Because we need to allow reading uncommitted messages as an
emergency fix to get some of our stuck consumers running again, we're
just going to flip-flop the hardcoded value here for now.